### PR TITLE
Fix TeamRam

### DIFF
--- a/My_Theme_Collection/TeamRam.theme.css
+++ b/My_Theme_Collection/TeamRam.theme.css
@@ -1767,9 +1767,19 @@
     opacity: 1;
 }
 
+/* Dividers */
+
 .divider-JfaTT5 {
     border: none;
 }
+
+/* For new unread messages */
+/*
+.divider-JfaTT5.da-isUnread {
+	border: 1px solid #f4acc5;
+}
+*/
+
 
 #app-mount .content-1o0f9g {
     color: white;
@@ -2363,3 +2373,16 @@
     background-color: #f4acc5;
     color: white;
 }
+
+
+/* Sidenav */
+
+.container-3w7J-x {
+	background-color: transparent;
+	/*background: rgba(0, 0, 0, 0.392);*/
+}
+
+.container-1taM1r {
+	background: rgba(0, 0, 0, 0.392);
+}
+


### PR DESCRIPTION
  * Sidenav transparency wasn't working
  * Also adds (commented) option to enable the divider for unread messages

There might be some other things which need to be fixed but I don't have enough time to check thoroughly.
My fixes are a bit dirty, at the end of the css file, so feel free to tell me where I should put them. I'm not used to Discord theming so here it is. Also I really like being able to see a divider before unread messages so I added this as a couple commented line in the file.

(Also I don't know if you'd want to update the version in the META tag at the beginning of the file.)